### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
     ],
     "description": "Generate synthetic data: flying foregrounds on top of backgrounds",
     "docker_image": "supervisely/synthetic:6.73.564",
-    "instance_version": "6.11.16",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",
     "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
         "data operations"
     ],
     "description": "Generate synthetic data: flying foregrounds on top of backgrounds",
-    "docker_image": "supervisely/synthetic:6.73.186",
+    "docker_image": "supervisely/synthetic:6.73.564",
     "instance_version": "6.11.16",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,3 @@
-supervisely==6.73.186
-supervisely[aug]==6.73.186
+supervisely==6.73.564
+supervisely[aug]==6.73.564
 albumentations==1.1.0


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
